### PR TITLE
Automate pre-commit checks via lefthook

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ pnpm deploy
 ## ESLint Configuration
 
 This project uses the latest ESLint 9 (flat config). Edit `eslint.config.js` as needed.
+
+## Tooling
+
+CLI tools (`lefthook`) are managed by [aqua](https://aquaproj.github.io/) with versions pinned in [aqua.yaml](aqua.yaml).
+
+### Install tools
+
+Install aqua itself first (see the [aqua installation guide](https://aquaproj.github.io/docs/install)), then install the pinned tools:
+
+```bash
+aqua install
+```
+
+### Set up git hooks
+
+[lefthook](lefthook.yml) runs lint and format checks on staged files before each commit. Register the hooks once after cloning:
+
+```bash
+lefthook install
+```

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+  - type: standard
+    ref: v4.502.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: evilmartians/lefthook@v2.1.6

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs}"
+      run: pnpm run lint
+    fmt:
+      glob: "*.{ts,tsx,js,jsx,mjs,cjs,json,md,yml,yaml,html,css}"
+      run: pnpm run fmt:check


### PR DESCRIPTION
## Summary
- Manage `lefthook` via aqua, pinned to v2.1.6.
- Add a pre-commit hook for the repository lint and format checks.
- Document aqua / lefthook setup steps in the README.

## Test plan
- [x] `lefthook validate`
- [x] `aqua which --version lefthook`
- [x] repository lint and format checks pass