### PR TITLE
Use Node 24 in CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,6 +17,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
       - name: Install
         run: pnpm install
       - name: Lint
@@ -30,6 +34,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
       - name: Install
         run: pnpm install
       - name: Format Check
@@ -43,6 +51,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
       - name: Install
         run: pnpm install
       - name: Test
@@ -58,6 +70,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
       - name: Install
         run: pnpm install
       - name: Deploy

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"version": "0.0.0",
 	"type": "module",
 	"packageManager": "pnpm@10",
+	"engines": {
+		"node": "24"
+	},
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc -b && vite build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+  - sharp
+  - workerd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,0 @@
-onlyBuiltDependencies:
-  - '@swc/core'
-  - esbuild
-  - sharp
-  - workerd


### PR DESCRIPTION
## Summary
- add package.json engines.node = 24
- make each CI job use actions/setup-node from package.json

## Context
pnpm v11 requires Node >=22.13, but the current workflow otherwise falls back to the runner default Node 20. This keeps the runtime source in package.json before Renovate pnpm v11 updates land.

## Validation
- git diff --check
- pnpm run fmt:check
- pnpm run lint