### PR TITLE
Verify aqua registry 4.532.0 after pnpm setup fix

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,7 +9,7 @@
 #   - all
 registries:
   - type: standard
-    ref: v4.531.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.532.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: evilmartians/lefthook@v2.1.9
   - name: suzuki-shunsuke/pinact@v4.1.0


### PR DESCRIPTION
## Summary
- update aquaproj/aqua-registry to v4.532.0
- validate the update on top of the merged pnpm setup fix

## Local validation
- CI=true pnpm install --frozen-lockfile
- lint and format check
- TypeScript project build
- tests and production build
- Cloudflare type generation with a clean generated-file diff
- pinact and zizmor